### PR TITLE
Improve efficiency in memory trace and device->host mem-copy

### DIFF
--- a/src/cu_compute_Pq.cu
+++ b/src/cu_compute_Pq.cu
@@ -26,8 +26,8 @@ __global__ void validate_info(int *info){
   if(idx>0) return;
   if(*info!=0){
     printf("info is: %d\n",*info);
-    printf("nonzero info. Aborting.\n");
-    asm("exit;");
+    printf("nonzero info. Aborting application.\n");
+    asm("trap;"); // nonzero info = cholesky or LU fails, then all threads should be stopped
   }
 }
 __global__ void validate_info(int *info, int N){
@@ -36,8 +36,8 @@ __global__ void validate_info(int *info, int N){
   for(int i=0;i<N;++i){
     if(*(info+i)!=0){
       printf("info is: %d\n",*(info+i));
-      printf("nonzero info for batched job: %d. Aborting.\n",i);
-      asm("exit;");
+      printf("nonzero info for batched job: %d. Aborting application.\n",i);
+      asm("trap;"); // nonzero info = cholesky or LU fails, then all threads should be stopped
     }
   }
 }

--- a/src/cu_routines.cu
+++ b/src/cu_routines.cu
@@ -297,7 +297,6 @@ namespace green::gpu {
     MPI_Win_sync(sigma_tau_host_shared.win());
     MPI_Win_unlock_all(sigma_tau_host_shared.win());
     // wait for all qkpts to complete
-    for (int i=0; i<=qkpts)
     if (!_low_device_memory and !_X2C) {
       MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0, 0, sigma_tau_host_shared.win());
       copy_Sigma_from_device_to_host(sigma_kstij_device, sigma_tau_host_shared.data(), _ink, _nao, _nts, _ns);

--- a/src/cu_routines.cu
+++ b/src/cu_routines.cu
@@ -299,7 +299,7 @@ namespace green::gpu {
     // wait for all qkpts to complete
     if (!_low_device_memory and !_X2C) {
       MPI_Win_lock(MPI_LOCK_EXCLUSIVE, 0, 0, sigma_tau_host_shared.win());
-      copy_Sigma_from_device_to_host(sigma_kstij_device, sigma_tau_host_shared.data(), _ink, _nao, _nts, _ns);
+      copy_Sigma_from_device_to_host(sigma_kstij_device, sigma_tau_host_shared.object().data(), _ink, _nao, _nts, _ns);
       MPI_Win_unlock(0, sigma_tau_host_shared.win());
     }
   }

--- a/src/green/gpu/cu_routines.h
+++ b/src/green/gpu/cu_routines.h
@@ -22,6 +22,8 @@
 #ifndef GREEN_GPU_CU_ROUTINES_H
 #define GREEN_GPU_CU_ROUTINES_H
 #include <green/gpu/common_defs.h>
+#include <green/utils/mpi_shared.h>
+#include <green/utils/mpi_utils.h>
 
 #include <cstring>
 
@@ -132,6 +134,7 @@ namespace green::gpu {
     using scalar_t     = typename cu_type_map<std::complex<prec>>::cxx_base_type;
     using cxx_complex  = typename cu_type_map<std::complex<prec>>::cxx_type;
     using cuda_complex = typename cu_type_map<std::complex<prec>>::cuda_type;
+    using St_type      = utils::shared_object<ztensor<5>>;
 
   public:
     cugw_utils(int _nts, int _nt_batch, int _nw_b, int _ns, int _nk, int _ink, int _nqkpt, int _NQ, int _nao,

--- a/src/green/gpu/cu_routines.h
+++ b/src/green/gpu/cu_routines.h
@@ -141,7 +141,7 @@ namespace green::gpu {
     ~cugw_utils();
 
     void solve(int _nts, int _ns, int _nk, int _ink, int _nao, const std::vector<size_t>& reduced_to_full,
-               const std::vector<size_t>& full_to_reduced, std::complex<double>* Vk1k2_Qij, ztensor<5>& Sigma_tskij_host,
+               const std::vector<size_t>& full_to_reduced, std::complex<double>* Vk1k2_Qij, St_type& Sigma_tskij_host,
                int _devices_rank, int _devices_size, bool _low_device_memory, int verbose, irre_pos_callback& irre_pos,
                mom_cons_callback& momentum_conservation, gw_reader1_callback<prec>& r1, gw_reader2_callback<prec>& r2);
 
@@ -163,7 +163,7 @@ namespace green::gpu {
     tensor<std::complex<prec>, 3>  V_Qim;
     tensor<std::complex<prec>, 4>  Gk1_stij;
     tensor<std::complex<prec>, 4>  Gk_smtij;
-    tensor<std::complex<prec>, 4>& Sigmak_stij = Gk_smtij;
+    tensor<std::complex<prec>, 4>  Sigmak_stij;
 
     cuda_complex*                  g_kstij_device;
     cuda_complex*                  g_ksmtij_device;

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -315,7 +315,7 @@ namespace green::gpu {
      * \param low_memory_mode - whether the whole self-energy allocated in memory or not
      * \param Sigma_stij_host - HHost stored self-energy object at a given momentum point
      */
-    void cleanup(bool low_memory_mode, cxx_complex* Sigma_stij_host);
+    void cleanup(bool low_memory_mode, cxx_complex* Sigmak_stij_host);
 
     //
     static std::size_t size(size_t nao, size_t naux, size_t nt, size_t nt_batch, size_t ns) {
@@ -427,7 +427,6 @@ namespace green::gpu {
     return qkpts[pos];
   }
 
-  using cxx_complex  = typename cu_type_map<std::complex<prec>>::cxx_type;
   /**
    * \brief returns an idle qkpt stream, otherwise waits until a stream is available
    * 
@@ -438,8 +437,8 @@ namespace green::gpu {
    * \return gw_qkpt<prec>* - pointer to idle qkpt
    */
   template <typename prec>
-  gw_qkpt<prec>* obtain_idle_qkpt_for_sigma(std::vector<gw_qkpt<prec>*>& qkpts,
-                                            bool low_memory_mode, cxx_complex* Sigmak_stij_host) {
+  gw_qkpt<prec>* obtain_idle_qkpt_for_sigma(std::vector<gw_qkpt<prec>*>& qkpts, bool low_memory_mode,
+                                            typename cu_type_map<std::complex<prec>>::cxx_type* Sigmak_stij_host) {
     static int pos = 0;
     pos++;
     if (pos >= qkpts.size()) pos = 0;
@@ -459,8 +458,8 @@ namespace green::gpu {
    * \param Sigmak_stij_host - cudaMallocHost buffer for transfering Sigma
    */
   template <typename prec>
-  void wait_and_clean_qkpts(std::vector<gw_qkpt<prec>*>& qkpts,
-                            bool low_memory_mode, cxx_complex* Sigmak_stij_host) {
+  void wait_and_clean_qkpts(std::vector<gw_qkpt<prec>*>& qkpts, bool low_memory_mode,
+                            typename cu_type_map<std::complex<prec>>::cxx_type* Sigmak_stij_host) {
     static int pos = 0;
     pos++;
     if (pos >= qkpts.size()) pos = 0;

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -427,6 +427,7 @@ namespace green::gpu {
     return qkpts[pos];
   }
 
+  using cxx_complex  = typename cu_type_map<std::complex<prec>>::cxx_type;
   /**
    * \brief returns an idle qkpt stream, otherwise waits until a stream is available
    * 

--- a/src/green/gpu/gw_gpu_kernel.h
+++ b/src/green/gpu/gw_gpu_kernel.h
@@ -80,6 +80,13 @@ namespace green::gpu {
     virtual void gw_innerloop(G_type& g, St_type& sigma_tau) = 0;
     void GW_check_devices_free_space();
 
+    /**
+     * \brief count and floating points operations per second achieved on GPU.
+     * This is not representative of the GPU capabilities, but instead, accounts for read/write overheads.
+     * The value is entirely in the context Green-MBPT solver.
+     */
+    void flops_achieved();
+
     /*
      * Read a chunk of Coulomb integral with given (k[0], k[3]) k-pair
      */

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -110,6 +110,7 @@ namespace green::gpu {
       MPI_Barrier(utils::context.global);
       statistics.end();
       statistics.print(utils::context.global);
+      flops_achieved();
 
       clean_MPI_structure();
       clean_shared_Coulomb();
@@ -117,6 +118,29 @@ namespace green::gpu {
       MPI_Barrier(utils::context.global);
       MPI_Type_free(&dt_matrix);
       MPI_Op_free(&matrix_sum_op);
+    }
+
+    void gw_gpu_kernel::flops_achieved() {
+      double gpu_time;
+      event_t cugw_event = statistics.event("Solve cuGW");
+      gpu_time = cugw_event.duration;
+
+      int myid;
+      MPI_Comm_rank(utils::context.global, &id);
+
+      if (!myid) {
+        MPI_Reduce(MPI_IN_PLACE, &gpu_time, 1, MPI_DOUBLE, MPI_SUM, 0, utils::context.global);
+      } else {
+        MPI_Reduce(&gpu_time, &gpu_time, 1, MPI_DOUBLE, MPI_SUM, 0, utils::context.global);
+      }
+
+      double flops = _flop_count / gpu_time;
+
+      if (!utils::context.global_rank && _verbose > 1) {
+        std::cout << "############ GPU FLOPs achieved ############" << std::endl;
+        std::cout << "FLOPs achieved: " << flops / 1.0e9 << " Giga flops." << std::endl;
+        std::cout << "###########################################################" << std::endl;
+      }
     }
 
     void scalar_gw_gpu_kernel::gw_innerloop(G_type& g, St_type& sigma_tau) {

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -110,7 +110,7 @@ namespace green::gpu {
       MPI_Barrier(utils::context.global);
       statistics.end();
       statistics.print(utils::context.global);
-      flops_achieved();
+      // flops_achieved();
 
       clean_MPI_structure();
       clean_shared_Coulomb();
@@ -122,13 +122,10 @@ namespace green::gpu {
 
     void gw_gpu_kernel::flops_achieved() {
       double gpu_time;
-      event_t cugw_event = statistics.event("Solve cuGW");
+      utils::event_t cugw_event = statistics.event("Solve cuGW");
       gpu_time = cugw_event.duration;
 
-      int myid;
-      MPI_Comm_rank(utils::context.global, &id);
-
-      if (!myid) {
+      if (!utils::context.global_rank) {
         MPI_Reduce(MPI_IN_PLACE, &gpu_time, 1, MPI_DOUBLE, MPI_SUM, 0, utils::context.global);
       } else {
         MPI_Reduce(&gpu_time, &gpu_time, 1, MPI_DOUBLE, MPI_SUM, 0, utils::context.global);


### PR DESCRIPTION
Proposing the following changes

1. Current copy of new self-energy from CUDA device to Host memory uses `cudaMemcpy`. This blocks the processes and further execution of kernels. Replacing this with `cudaMemcpyAsync`. This should, in principle, speed up the code.
2. To implement (1), function signatures are updated. Two-step process involving `cudaMemcpy` to a buffer on host memory, followed by writing the host buffer to shared-memory Self-energy is introduced.
3. Adding a function to measure total FLOPs achieved (including read/write steps).
4. Updates in error handling for Cholesky / LU failures when computing polarization P from P0. 
