### PR TITLE
Async copy of self-energyy from Device to Host

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         module load BuildEnv/gcc-12.2.0.lua cuda-sdk;
         mkdir -p build;
         cd build;
-        cmake -DGPU_ARCHS="61;70;75;80;86;90" -DCMAKE_CXX_FLAGS=" --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-arcs -ftest-coverage " ..;
+        cmake -DGPU_ARCHS="61" -DCMAKE_CXX_FLAGS=" --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-arcs -ftest-coverage " ..;
         make -j 8;
 
     - name: Test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,7 @@ jobs:
         module load BuildEnv/gcc-12.2.0.lua cuda-sdk;
         mkdir -p build;
         cd build;
-        cmake -DGPU_ARCHS="61" -DCMAKE_CXX_FLAGS=" --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-arcs -ftest-coverage " ..;
+        cmake -DGPU_ARCHS="61;70;75;80;86;90" -DCMAKE_CXX_FLAGS=" --coverage -fno-inline -fno-inline-small-functions -fno-default-inline -fprofile-arcs -ftest-coverage " ..;
         make -j 8;
 
     - name: Test

--- a/src/cu_routines.cu
+++ b/src/cu_routines.cu
@@ -309,25 +309,27 @@ namespace green::gpu {
             r2(k, k1, k1_reduced_id, k_vector, V_Qim, Vk1k2_Qij, Gk1_stij, need_minus_k1);
             if (!_devices_rank) POP_RANGE;
 
-            if (!_devices_rank) PUSH_RANGE("r1: wait / copy data back to host and free qkpt stream", 2);
+            if (!_devices_rank) PUSH_RANGE("r1: wait / copy data back to host and free qkpt stream", 3);
             gw_qkpt<prec>* qkpt = obtain_idle_qkpt_for_sigma(qkpts, _low_device_memory, Sigmak_stij, Sigma_tskij_host, _X2C);
             if (!_devices_rank) POP_RANGE;
 
             qkpt->set_k_red_id(k_reduced_id);
             if (_low_device_memory) {
               if (!_X2C) {
-                if (!_devices_rank) PUSH_RANGE("setup: copy data to device", 3);
+                if (!_devices_rank) PUSH_RANGE("setup: copy data to device", 4);
                 qkpt->set_up_qkpt_second(Gk1_stij.data(), V_Qim.data(), k_reduced_id, k1_reduced_id, need_minus_k1);
+                if (!_devices_rank) POP_RANGE;
+                if (!_devices_rank) PUSH_RANGE("Sigma contraction", 5);
                 qkpt->compute_second_tau_contraction(Sigmak_stij.data(),
                                                      qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q));
                 if (!_devices_rank) POP_RANGE;
                 // copy_Sigma(Sigma_tskij_host, Sigmak_stij, k_reduced_id, _nts, _ns);
               } else {
-                if (!_devices_rank) PUSH_RANGE("setup: copy data to device", 3);
+                if (!_devices_rank) PUSH_RANGE("setup: copy data to device", 4);
                 // In 2cGW, G(-k) = G*(k) has already been addressed in r2()
                 qkpt->set_up_qkpt_second(Gk1_stij.data(), V_Qim.data(), k_reduced_id, k1_reduced_id, false);
                 if (!_devices_rank) POP_RANGE;
-                if (!_devices_rank) PUSH_RANGE("Sigma contraction", 4);
+                if (!_devices_rank) PUSH_RANGE("Sigma contraction", 5);
                 qkpt->compute_second_tau_contraction_2C(Sigmak_stij.data(),
                                                         qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q));
                 if (!_devices_rank) POP_RANGE;

--- a/src/cu_routines.cu
+++ b/src/cu_routines.cu
@@ -195,7 +195,7 @@ namespace green::gpu {
                                int _devCount_per_node) :
       _low_device_memory(low_device_memory), qkpts(_nqkpt), V_Qpm(_NQ, _nao, _nao), V_Qim(_NQ, _nao, _nao),
       Gk1_stij(_ns, _nts, _nao, _nao), Gk_smtij(_ns, _nts, _nao, _nao),
-      qpt(_nao, _NQ, _nts, _nw_b, Ttn_FB.data(), Tnt_BF.data(), cuda_lin_solver) {
+      qpt(_nao, _NQ, _nts, _nw_b, Ttn_FB.data(), Tnt_BF.data(), cuda_lin_solver), _qkpt_handles(_nqkpt) {
     if (cudaSetDevice(_intranode_rank % _devCount_per_node) != cudaSuccess) throw std::runtime_error("Error in cudaSetDevice2");
     if (cublasCreate(&_handle) != CUBLAS_STATUS_SUCCESS)
       throw std::runtime_error("Rank " + std::to_string(_myid) + ": error initializing cublas");
@@ -224,7 +224,6 @@ namespace green::gpu {
 
     qpt.init(&_handle, &_solver_handle);
     // Each process gets one cuda runner for qpoints
-    _qkpt_handles.resize(_nqkpt);
     for (int i = 0; i < _nqkpt; ++i) {
       // TODO: Do we need to add the same handle to qkpt as qpt?
       if (cublasCreate(&_qkpt_handles[i]) != CUBLAS_STATUS_SUCCESS)

--- a/src/cu_routines.cu
+++ b/src/cu_routines.cu
@@ -324,7 +324,7 @@ namespace green::gpu {
                 if (!_devices_rank) POP_RANGE;
                 if (!_devices_rank) PUSH_RANGE("Sigma contraction", 5);
                 qkpt->compute_second_tau_contraction(Sigmak_stij.data(),
-                                                     qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q));
+                                                     qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q, !_devices_rank));
                 if (!_devices_rank) POP_RANGE;
                 // copy_Sigma(Sigma_tskij_host, Sigmak_stij, k_reduced_id, _nts, _ns);
               } else {
@@ -334,7 +334,7 @@ namespace green::gpu {
                 if (!_devices_rank) POP_RANGE;
                 if (!_devices_rank) PUSH_RANGE("Sigma contraction", 5);
                 qkpt->compute_second_tau_contraction_2C(Sigmak_stij.data(),
-                                                        qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q));
+                                                        qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q, !_devices_rank));
                 if (!_devices_rank) POP_RANGE;
                 // copy_Sigma_2c(Sigma_tskij_host, Sigmak_stij, k_reduced_id, _nts);
               }

--- a/src/cu_routines.cu
+++ b/src/cu_routines.cu
@@ -21,29 +21,6 @@
 
 #include <green/gpu/cu_routines.h>
 
-// #ifdef USE_NVTX
-#include "nvtx3/nvToolsExt.h"
-
-const uint32_t colors[] = { 0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff };
-const int num_colors = sizeof(colors)/sizeof(uint32_t);
-
-#define PUSH_RANGE(name,cid) { \
-	int color_id = cid; \
-	color_id = color_id%num_colors;\
-	nvtxEventAttributes_t eventAttrib = {0}; \
-	eventAttrib.version = NVTX_VERSION; \
-	eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
-	eventAttrib.colorType = NVTX_COLOR_ARGB; \
-	eventAttrib.color = colors[color_id]; \
-	eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
-	eventAttrib.message.ascii = name; \
-	nvtxRangePushEx(&eventAttrib); \
-}
-#define POP_RANGE nvtxRangePop();
-// #else
-// #define PUSH_RANGE(name,cid)
-// #define POP_RANGE
-// #endif
 
 __global__ void initialize_array(cuDoubleComplex* array, cuDoubleComplex value, int count) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
@@ -240,7 +217,6 @@ namespace green::gpu {
                                int verbose, irre_pos_callback& irre_pos, mom_cons_callback& momentum_conservation,
                                gw_reader1_callback<prec>& r1, gw_reader2_callback<prec>& r2) {
     // this is the main GW loop
-    if (!_devices_rank) PUSH_RANGE("Solve in CU_ROUTINES begin", 0);
     if (!_devices_rank && verbose > 0) std::cout << "GW main loop" << std::endl;
     qpt.verbose() = verbose;
 
@@ -248,7 +224,6 @@ namespace green::gpu {
       if (verbose > 2) std::cout << "q = " << q_reduced_id << std::endl;
       size_t q = reduced_to_full[q_reduced_id];
       qpt.reset_Pqk0();
-      if (!_devices_rank) PUSH_RANGE("Build P0", 1);
       for (size_t k = 0; k < _nk; ++k) {
         std::array<size_t, 4> k_vector      = momentum_conservation({
             {k, 0, q}
@@ -259,13 +234,10 @@ namespace green::gpu {
         bool                  need_minus_k  = reduced_to_full[k_reduced_id] != k;
         bool                  need_minus_k1 = reduced_to_full[k1_reduced_id] != k1;
 
-        if (!_devices_rank) PUSH_RANGE("r1: read ints and G(k2)", 2);
         r1(k, k1, k_reduced_id, k1_reduced_id, k_vector, V_Qpm, Vk1k2_Qij, Gk_smtij, Gk1_stij, need_minus_k, need_minus_k1);
-        if (!_devices_rank) POP_RANGE;
 
         gw_qkpt<prec>* qkpt = obtain_idle_qkpt(qkpts);
 
-        if (!_devices_rank) PUSH_RANGE("setup: copy data to device", 3);
         if (_low_device_memory) {
           if (!_X2C) {
             qkpt->set_up_qkpt_first(Gk1_stij.data(), Gk_smtij.data(), V_Qpm.data(), k_reduced_id, need_minus_k, k1_reduced_id,
@@ -277,14 +249,9 @@ namespace green::gpu {
         } else {
           qkpt->set_up_qkpt_first(nullptr, nullptr, V_Qpm.data(), k_reduced_id, need_minus_k, k1_reduced_id, need_minus_k1);
         }
-        if (!_devices_rank) POP_RANGE;
-        if (!_devices_rank) PUSH_RANGE("P0 contraction", 4);
         qkpt->compute_first_tau_contraction(qpt.Pqk0_tQP(qkpt->all_done_event()), qpt.Pqk0_tQP_lock());
-        if (!_devices_rank) POP_RANGE;
       }
 
-      if (!_devices_rank) POP_RANGE;
-      if (!_devices_rank) PUSH_RANGE("Build P", 1);
 
       qpt.wait_for_kpts();
       qpt.scale_Pq0_tQP(1. / _nk);
@@ -292,8 +259,6 @@ namespace green::gpu {
       qpt.compute_Pq();
       qpt.transform_wt();
 
-      if (!_devices_rank) POP_RANGE;
-      if (!_devices_rank) PUSH_RANGE("Build Sigma", 1);
 
       // Write to Sigma(k), k belongs to _ink
       for (size_t k_reduced_id = 0; k_reduced_id < _ink; ++k_reduced_id) {
@@ -308,34 +273,22 @@ namespace green::gpu {
             bool                  need_minus_k1 = reduced_to_full[k1_reduced_id] != k1;
             bool                  need_minus_q  = reduced_to_full[q_reduced_id] != q_or_qinv;
 
-            if (!_devices_rank) PUSH_RANGE("r2: read ints and G(k3)", 2);
             r2(k, k1, k1_reduced_id, k_vector, V_Qim, Vk1k2_Qij, Gk1_stij, need_minus_k1);
-            if (!_devices_rank) POP_RANGE;
 
-            if (!_devices_rank) PUSH_RANGE("r1: wait / copy data back to host and free qkpt stream", 3);
             gw_qkpt<prec>* qkpt = obtain_idle_qkpt_for_sigma(qkpts, _low_device_memory, Sigmak_stij, Sigma_tskij_host, _X2C);
-            if (!_devices_rank) POP_RANGE;
 
             qkpt->set_k_red_id(k_reduced_id);
             if (_low_device_memory) {
               if (!_X2C) {
-                if (!_devices_rank) PUSH_RANGE("setup: copy data to device", 4);
                 qkpt->set_up_qkpt_second(Gk1_stij.data(), V_Qim.data(), k_reduced_id, k1_reduced_id, need_minus_k1);
-                if (!_devices_rank) POP_RANGE;
-                if (!_devices_rank) PUSH_RANGE("Sigma contraction", 5);
                 qkpt->compute_second_tau_contraction(Sigmak_stij.data(),
-                                                     qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q, !_devices_rank));
-                if (!_devices_rank) POP_RANGE;
+                                                     qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q));
                 // copy_Sigma(Sigma_tskij_host, Sigmak_stij, k_reduced_id, _nts, _ns);
               } else {
-                if (!_devices_rank) PUSH_RANGE("setup: copy data to device", 4);
                 // In 2cGW, G(-k) = G*(k) has already been addressed in r2()
                 qkpt->set_up_qkpt_second(Gk1_stij.data(), V_Qim.data(), k_reduced_id, k1_reduced_id, false);
-                if (!_devices_rank) POP_RANGE;
-                if (!_devices_rank) PUSH_RANGE("Sigma contraction", 5);
                 qkpt->compute_second_tau_contraction_2C(Sigmak_stij.data(),
-                                                        qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q, !_devices_rank));
-                if (!_devices_rank) POP_RANGE;
+                                                        qpt.Pqk_tQP(qkpt->all_done_event(), qkpt->stream(), need_minus_q));
                 // copy_Sigma_2c(Sigma_tskij_host, Sigmak_stij, k_reduced_id, _nts);
               }
             } else {
@@ -345,16 +298,12 @@ namespace green::gpu {
           }
         }
       }
-      if (!_devices_rank) POP_RANGE;
     }
-    if (!_devices_rank) PUSH_RANGE("Wait for remaining qkpt workers", 1);
     wait_and_clean_qkpts(qkpts, _low_device_memory, Sigmak_stij, Sigma_tskij_host, _X2C);
-    if (!_devices_rank) POP_RANGE;
     cudaDeviceSynchronize();
     if (!_low_device_memory and !_X2C) {
       copy_Sigma_from_device_to_host(sigma_kstij_device, Sigma_tskij_host.data(), _ink, _nao, _nts, _ns);
     }
-    if (!_devices_rank) POP_RANGE;
   }
 
   template <typename prec>

--- a/src/cu_routines.cu
+++ b/src/cu_routines.cu
@@ -202,11 +202,11 @@ namespace green::gpu {
     qpt.init(&_handle, &_solver_handle);
     // Each process gets one cuda runner for qpoints
     for (int i = 0; i < _nqkpt; ++i) {
-      // TODO: Do we need to add the same handle to qkpt as qpt?
       if (cublasCreate(&_qkpt_handles[i]) != CUBLAS_STATUS_SUCCESS)
         throw std::runtime_error("Rank " + std::to_string(_myid) + ": error initializing cublas");
-      qkpts[i] = new gw_qkpt<prec>(_nao, _NQ, _ns, _nts, _nt_batch, &_qkpt_handles[i], g_kstij_device, g_ksmtij_device, sigma_kstij_device,
-                                   sigma_k_locks);
+      // initialize qkpt workers
+      qkpts[i] = new gw_qkpt<prec>(_nao, _NQ, _ns, _nts, _nt_batch, &_qkpt_handles[i],
+                                   g_kstij_device, g_ksmtij_device, sigma_kstij_device, sigma_k_locks);
     }
   }
 

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -348,7 +348,7 @@ namespace green::gpu {
       throw std::runtime_error("failure allocating V on host");
     if (_low_memory_requirement) {
       if (cudaMallocHost(&Gk1_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
-        throw std::runtime_error("failure allocating Gk1_tsij on host");
+        throw std::runtime_error("failure allocating Gk1_stij on host");
       if (cudaMallocHost(&Gk_smtij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
         throw std::runtime_error("failure allocating Gk_smtij on host");
       if (cudaMallocHost(&Sigmak_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -351,8 +351,8 @@ namespace green::gpu {
         throw std::runtime_error("failure allocating Gk1_tsij on host");
       if (cudaMallocHost(&Gk_smtij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
         throw std::runtime_error("failure allocating Gk_smtij on host");
-      // Reuse Gk_smtij_buffer_ for sigmak_stij_buffer_ to save memory since they are not needed at the same time
-      Sigmak_stij_buffer_ = Gk_smtij_buffer_;
+      if (cudaMallocHost(&Sigmak_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
+        throw std::runtime_error("failure allocating Sigmak_stij on host");
     }
 
     if (cudaMalloc(&Pqk0_tQP_local_, nt_batch_ * naux2_ * sizeof(cuda_complex)) != cudaSuccess)

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -154,6 +154,12 @@ namespace green::gpu {
   template <typename prec>
   typename gw_qpt<prec>::cuda_complex* gw_qpt<prec>::Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream,
                                                              int need_minus_q) {
+    // make sure the other stream waits until our data is ready (i.e. the equation system solved)
+    if (cudaStreamWaitEvent(calc_stream, polarization_ready_event_, 0 /*cudaEventWaitDefault*/))
+      throw std::runtime_error("could not wait for data");
+    // make sure this stream waits until the other calculation is done
+    if (cudaStreamWaitEvent(stream_, all_done_event, 0 /*cudaEventWaitDefault*/))
+      throw std::runtime_error("could not wait for data");
     return (!need_minus_q) ? Pqk_tQP_ : Pqk_tQP_conj_;
   }
 

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -348,11 +348,11 @@ namespace green::gpu {
       throw std::runtime_error("failure allocating V on host");
     if (_low_memory_requirement) {
       if (cudaMallocHost(&Gk1_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
-        throw std::runtime_error("failure allocating Gk_tsij on host");
+        throw std::runtime_error("failure allocating Gk1_tsij on host");
       if (cudaMallocHost(&Gk_smtij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
-        throw std::runtime_error("failure allocating Gk_tsij on host");
+        throw std::runtime_error("failure allocating Gk_smtij on host");
       if (cudaMallocHost(&Sigmak_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
-        throw std::runtime_error("failure allocating Gk_tsij on host");
+        throw std::runtime_error("failure allocating Sigmak_stij on host");
       // Sigmak_stij_buffer_ = Gk_smtij_buffer_;
     }
 

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -20,7 +20,29 @@
  */
 
 #include <green/gpu/cugw_qpt.h>
-#include <nvtx3/nvtx3.hpp>
+// #ifdef USE_NVTX
+#include "nvtx3/nvToolsExt.h"
+
+const uint32_t colors[] = { 0xff00ff00, 0xff0000ff, 0xffffff00, 0xffff00ff, 0xff00ffff, 0xffff0000, 0xffffffff };
+const int num_colors = sizeof(colors)/sizeof(uint32_t);
+
+#define PUSH_RANGE(name,cid) { \
+	int color_id = cid; \
+	color_id = color_id%num_colors;\
+	nvtxEventAttributes_t eventAttrib = {0}; \
+	eventAttrib.version = NVTX_VERSION; \
+	eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE; \
+	eventAttrib.colorType = NVTX_COLOR_ARGB; \
+	eventAttrib.color = colors[color_id]; \
+	eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII; \
+	eventAttrib.message.ascii = name; \
+	nvtxRangePushEx(&eventAttrib); \
+}
+#define POP_RANGE nvtxRangePop();
+// #else
+// #define PUSH_RANGE(name,cid)
+// #define POP_RANGE
+// #endif
 namespace green::gpu {
   template<typename prec>
   gw_qpt<prec>::gw_qpt(int nao, int naux, int nt, int nw_b,
@@ -152,14 +174,15 @@ namespace green::gpu {
 
   template <typename prec>
   typename gw_qpt<prec>::cuda_complex* gw_qpt<prec>::Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream,
-                                                             int need_minus_q) {
-    nvtx3::scoped_range pol_range{"Getting P for Sigma contraction"};
+                                                             int need_minus_q, bool profile) {
+    if (profile) PUSH_RANGE("Retrieve P for Sigma contraction", 6);
     // make sure the other stream waits until our data is ready (i.e. the equation system solved)
     if (cudaStreamWaitEvent(calc_stream, polarization_ready_event_, 0 /*cudaEventWaitDefault*/))
       throw std::runtime_error("could not wait for data");
     // make sure this stream waits until the other calculation is done
     if (cudaStreamWaitEvent(stream_, all_done_event, 0 /*cudaEventWaitDefault*/))
       throw std::runtime_error("could not wait for data");
+    if (profile) POP_RANGE;
     return (!need_minus_q) ? Pqk_tQP_ : Pqk_tQP_conj_;
   }
 

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -153,7 +153,7 @@ namespace green::gpu {
   template <typename prec>
   typename gw_qpt<prec>::cuda_complex* gw_qpt<prec>::Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream,
                                                              int need_minus_q) {
-    nvtx3::scped_range pol_range{"Getting P for Sigma contraction"};
+    nvtx3::scoped_range pol_range{"Getting P for Sigma contraction"};
     // make sure the other stream waits until our data is ready (i.e. the equation system solved)
     if (cudaStreamWaitEvent(calc_stream, polarization_ready_event_, 0 /*cudaEventWaitDefault*/))
       throw std::runtime_error("could not wait for data");

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -651,7 +651,6 @@ namespace green::gpu {
   void gw_qkpt<prec>::copy_Sigma_2c(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij) {
     size_t    nao = Sigmak_stij.shape()[3];
     size_t    nso = 2 * nao;
-    MatrixXcf Sigma_ij(nso, nso);
     for (size_t ss = 0; ss < 3; ++ss) {
       size_t a       = (ss % 2 == 0) ? 0 : 1;
       size_t b       = ((ss + 1) / 2 != 1) ? 0 : 1;

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -532,44 +532,8 @@ namespace green::gpu {
     release_lock<<<1, 1, 0, stream_>>>(Pqk0_tQP_lock);
   }
 
-  // template <typename prec>
-  // void gw_qkpt<prec>::async_compute_second_tau_contraction(ztensor<5>& Sigma_tskij_host, cxx_complex* Sigmak_stij_host,
-  //                                                          cuda_complex* Pqk_tQP) {}
-  //   cuda_complex  one     = cu_type_map<cxx_complex>::cast(1., 0.);
-  //   cuda_complex  zero    = cu_type_map<cxx_complex>::cast(0., 0.);
-  //   cuda_complex  m1      = cu_type_map<cxx_complex>::cast(-1., 0.);
-  //   cuda_complex* Y1t_Qin = X1t_tmQ_;  // name change, reuse memory
-  //   cuda_complex* Y2t_inP = X2t_Ptm_;  // name change, reuse memory
-  //   cublasSetStream(*handle_, stream_);
-  //   for (int s = 0; s < ns_; ++s) {
-  //     for (int t = 0; t < nt_; t += nt_batch_) {
-  //       int st      = s * nt_ + t;
-  //       int nt_mult = std::min(nt_batch_, nt_ - t);
-  //       // Y1_Qin = V_Qim * G1_mn; G1_mn = G^{k1}(t)_mn
-  //       if (GEMM_STRIDED_BATCHED(*handle_, CUBLAS_OP_N, CUBLAS_OP_N, nao_, nauxnao_, nao_, &one, g_stij_ + st * nao2_, nao_,
-  //                                nao2_, V_Qim_, nao_, 0, &zero, Y1t_Qin, nao_, nauxnao2_, nt_mult) != CUBLAS_STATUS_SUCCESS) {
-  //         throw std::runtime_error("GEMM_STRIDED_BATCHED fails on gw_qkpt.compute_second_tau_contraction().");
-  //       }
-  //       // Y2_inP = Y1_Qin * Pq_QP
-  //       if (GEMM_STRIDED_BATCHED(*handle_, CUBLAS_OP_N, CUBLAS_OP_T, naux_, nao2_, naux_, &one, Pqk_tQP + t * naux2_, naux_,
-  //                                naux2_, Y1t_Qin, nao2_, nauxnao2_, &zero, Y2t_inP, naux_, nauxnao2_,
-  //                                nt_mult) != CUBLAS_STATUS_SUCCESS) {
-  //         throw std::runtime_error("GEMM_STRIDED_BATCHED fails on gw_qkpt.compute_second_tau_contraction().");
-  //       }
-  //       // Sigma_ij = Y2_inP V_nPj
-  //       if (GEMM_STRIDED_BATCHED(*handle_, CUBLAS_OP_N, CUBLAS_OP_N, nao_, nao_, nauxnao_, &m1, V_nPj_, nao_, 0, Y2t_inP,
-  //                                nauxnao_, nauxnao2_, &zero, sigmak_stij_ + st * nao2_, nao_, nao2_,
-  //                                nt_mult) != CUBLAS_STATUS_SUCCESS) {
-  //         throw std::runtime_error("GEMM_STRIDED_BATCHED fails on gw_qkpt.compute_second_tau_contraction().");
-  //       }
-  //     }
-  //   }
-  //   write_sigma(_low_memory_requirement, Sigmak_stij_host);
-  //   cudaEventRecord(all_done_event_);
-  // }
-
   template <typename prec>
-  void gw_qkpt<prec>::compute_second_tau_contraction(cxx_complex* Sigmak_stij_host, cuda_complex* Pqk_tQP) {
+  void gw_qkpt<prec>::compute_second_tau_contraction(cuda_complex* Pqk_tQP) {
     cuda_complex  one     = cu_type_map<cxx_complex>::cast(1., 0.);
     cuda_complex  zero    = cu_type_map<cxx_complex>::cast(0., 0.);
     cuda_complex  m1      = cu_type_map<cxx_complex>::cast(-1., 0.);
@@ -604,7 +568,7 @@ namespace green::gpu {
   }
 
   template <typename prec>
-  void gw_qkpt<prec>::compute_second_tau_contraction_2C(cxx_complex* Sigmak_stij_host, cuda_complex* Pqk_tQP) {
+  void gw_qkpt<prec>::compute_second_tau_contraction_2C(cuda_complex* Pqk_tQP) {
     cuda_complex  one     = cu_type_map<cxx_complex>::cast(1., 0.);
     cuda_complex  zero    = cu_type_map<cxx_complex>::cast(0., 0.);
     cuda_complex  m1      = cu_type_map<cxx_complex>::cast(-1., 0.);
@@ -654,8 +618,7 @@ namespace green::gpu {
     } else {
       // Copy sigmak_stij_ back to CPU
       cudaMemcpyAsync(Sigmak_stij_buffer_, sigmak_stij_, ns_ * ntnao2_ * sizeof(cuda_complex), cudaMemcpyDeviceToHost, stream_);
-      cleanup_req_ = true;
-      // std::memcpy(Sigmak_stij_host, Sigmak_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex));
+      cleanup_req_ = true; // This is required in addition to the all_done_event_ to indicate that we need to copy back to host. For initial states, this is not needed.
     }
   }
 
@@ -665,8 +628,6 @@ namespace green::gpu {
     // Block the stream until all the tasks are completed
     if (require_cleanup()) {
       cudaStreamSynchronize(stream_);
-      // TODO: Why do we have another intermediate for Sigma(k)?
-      // I iunderstand that this is not the cuda malloc buffer, but simply a normal one.
       std::memcpy(Sigmak_stij_host.data(), Sigmak_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex));
       if (!x2c) {
         copy_Sigma(Sigma_tskij_host, Sigmak_stij_host);

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -385,6 +385,7 @@ namespace green::gpu {
     if (_low_memory_requirement) {
       cudaFreeHost(Gk1_stij_buffer_);
       cudaFreeHost(Gk_smtij_buffer_);
+      cudaFreeHost(Sigmak_stij_buffer_);
     }
     if (require_cleanup()) {
       throw std::runtime_error("cleanup of self-energy was not done correctly.");

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -154,12 +154,6 @@ namespace green::gpu {
   template <typename prec>
   typename gw_qpt<prec>::cuda_complex* gw_qpt<prec>::Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream,
                                                              int need_minus_q) {
-    // make sure the other stream waits until our data is ready (i.e. the equation system solved)
-    if (cudaStreamWaitEvent(calc_stream, polarization_ready_event_, 0 /*cudaEventWaitDefault*/))
-      throw std::runtime_error("could not wait for data");
-    // make sure this stream waits until the other calculation is done
-    if (cudaStreamWaitEvent(stream_, all_done_event, 0 /*cudaEventWaitDefault*/))
-      throw std::runtime_error("could not wait for data");
     return (!need_minus_q) ? Pqk_tQP_ : Pqk_tQP_conj_;
   }
 

--- a/src/cugw_qpt.cu
+++ b/src/cugw_qpt.cu
@@ -351,9 +351,8 @@ namespace green::gpu {
         throw std::runtime_error("failure allocating Gk1_tsij on host");
       if (cudaMallocHost(&Gk_smtij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
         throw std::runtime_error("failure allocating Gk_smtij on host");
-      if (cudaMallocHost(&Sigmak_stij_buffer_, ns_ * ntnao2_ * sizeof(cxx_complex)) != cudaSuccess)
-        throw std::runtime_error("failure allocating Sigmak_stij on host");
-      // Sigmak_stij_buffer_ = Gk_smtij_buffer_;
+      // Reuse Gk_smtij_buffer_ for sigmak_stij_buffer_ to save memory since they are not needed at the same time
+      Sigmak_stij_buffer_ = Gk_smtij_buffer_;
     }
 
     if (cudaMalloc(&Pqk0_tQP_local_, nt_batch_ * naux2_ * sizeof(cuda_complex)) != cudaSuccess)

--- a/src/green/gpu/cu_routines.h
+++ b/src/green/gpu/cu_routines.h
@@ -155,6 +155,7 @@ namespace green::gpu {
     bool                           _low_device_memory;
     cublasHandle_t                 _handle;
     cusolverDnHandle_t             _solver_handle;
+    std::vector<cublasHandle_t>    _qkpt_handles;
 
     gw_qpt<prec>                   qpt;
     std::vector<gw_qkpt<prec>*>    qkpts;

--- a/src/green/gpu/cu_routines.h
+++ b/src/green/gpu/cu_routines.h
@@ -155,7 +155,7 @@ namespace green::gpu {
     bool                           _low_device_memory;
     cublasHandle_t                 _handle;
     cusolverDnHandle_t             _solver_handle;
-    std::vector<cublasHandle_t>    _qkpt_handles;  // list of cublas handles for qkpt streams
+    std::vector<cublasHandle_t>    _qkpt_cublas_handles;  // list of cublas handles for qkpt streams
 
     gw_qpt<prec>                   qpt;
     std::vector<gw_qkpt<prec>*>    qkpts;

--- a/src/green/gpu/cu_routines.h
+++ b/src/green/gpu/cu_routines.h
@@ -155,7 +155,7 @@ namespace green::gpu {
     bool                           _low_device_memory;
     cublasHandle_t                 _handle;
     cusolverDnHandle_t             _solver_handle;
-    std::vector<cublasHandle_t>    _qkpt_handles;
+    std::vector<cublasHandle_t>    _qkpt_handles;  // list of cublas handles for qkpt streams
 
     gw_qpt<prec>                   qpt;
     std::vector<gw_qkpt<prec>*>    qkpts;

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -283,10 +283,10 @@ namespace green::gpu {
     void write_sigma(bool low_memory_mode = false);
 
     /**
-     * \brief return the status of copy_selfenergy from device to host
+     * \brief return the status of copy_selfenergy from device to host.
+     * Return value of `false` means stream is ready for next calculation without cleanup.
      * 
-     * \return false - not required, stream ready for next calculation
-     * \return true - required
+     * \return true if cleanup is required, false otherwise
      */
     bool require_cleanup(){
       return cleanup_req_; 

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -262,24 +262,24 @@ namespace green::gpu {
      */
     void write_P0(int t, cuda_complex* Pqk0_tQP, int* Pqk0_tQP_lock);
 
-    /**
-     * \brief Using dressed GW polarization compute self-energy at a given momentum point
-     * 
-     * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
-     * \param Pqk_tQP Dressed polarization bubble
-     * \param Sigma_tskij_host host copy of full self-energy for MPI task assigned to the current device
-     */
-    void async_compute_second_tau_contraction(cxx_complex* Sigma_stij_host=nullptr,
-                                              cuda_complex* Pqk_tQP=nullptr, ztensor<5>& Sigma_tskij_host);
-    /**
-     * \brief Using dressed GW polarization compute self-energy at a given momentum point (X2C version)
-     * 
-     * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
-     * \param Pqk_tQP Dressed polarization bubble
-     * \param Sigma_tskij_host host copy of full self-energy for MPI task assigned to the current device
-     */
-    void async_compute_second_tau_contraction_2C(cxx_complex* Sigma_stij_host=nullptr,
-                                                 cuda_complex* Pqk_tQP=nullptr, ztensor<5>& Sigma_tskij_host);
+    // /**
+    //  * \brief Using dressed GW polarization compute self-energy at a given momentum point
+    //  * 
+    //  * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
+    //  * \param Pqk_tQP Dressed polarization bubble
+    //  * \param Sigma_tskij_host host copy of full self-energy for MPI task assigned to the current device
+    //  */
+    // void async_compute_second_tau_contraction(ztensor<5>& Sigma_tskij_host, cxx_complex* Sigma_stij_host=nullptr,
+    //                                           cuda_complex* Pqk_tQP=nullptr);
+    // /**
+    //  * \brief Using dressed GW polarization compute self-energy at a given momentum point (X2C version)
+    //  * 
+    //  * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
+    //  * \param Pqk_tQP Dressed polarization bubble
+    //  * \param Sigma_tskij_host host copy of full self-energy for MPI task assigned to the current device
+    //  */
+    // void async_compute_second_tau_contraction_2C(ztensor<5>& Sigma_tskij_host, cxx_complex* Sigma_stij_host=nullptr,
+    //                                              cuda_complex* Pqk_tQP=nullptr);
 
     /**
      * \brief Using dressed GW polarization compute self-energy at a given momentum point
@@ -325,7 +325,7 @@ namespace green::gpu {
      * \brief 
      * 
      */
-    void copy_Sigma(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij)
+    void copy_Sigma(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij);
 
     /**
      * \brief 
@@ -334,7 +334,7 @@ namespace green::gpu {
      * \param Sigmak_stij 
      * \param k_id 
      */
-    void copy_Sigma_2c(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij)
+    void copy_Sigma_2c(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij);
 
     /**
      * \brief Check if cuda devices are budy
@@ -492,9 +492,9 @@ namespace green::gpu {
   void wait_and_clean_qkpts(std::vector<gw_qkpt<prec>*>& qkpts, bool low_memory_mode,
                             tensor<std::complex<prec>,4>& Sigmak_stij_host,
                             ztensor<5>& Sigma_tskij_shared, bool x2c) {
-    if (!utils::context.global_rank) {
-      std::cout << "\nDEBUG: Waiting for all qkpts to finish working\n" << std::endl;
-    }
+    // if (!utils::context.global_rank) {
+    //   std::cout << "\nDEBUG: Waiting for all qkpts to finish working\n" << std::endl;
+    // }
     static int pos = 0;
     pos++;
     if (pos >= qkpts.size()) pos = 0;
@@ -505,9 +505,9 @@ namespace green::gpu {
       }
       qkpts[pos]->cleanup(low_memory_mode, Sigmak_stij_host, Sigma_tskij_shared, x2c);
     }
-    if (!utils::context.global_rank) {
-      std::cout << "\nDEBUG: Cleanup of qkpts completed\n" << std::endl;
-    }
+    // if (!utils::context.global_rank) {
+    //   std::cout << "\nDEBUG: Cleanup of qkpts completed\n" << std::endl;
+    // }
     return;
   }
 

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -74,7 +74,7 @@ namespace green::gpu {
      * \param need_minus_q we need to get Pqk_tQP_conj_ for a (-q) point
      * \return Pqk_tQP or Pqk_tQP_conj array for dressed polarization
      */
-    cuda_complex* Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream, int need_minus_q, bool profile=false);
+    cuda_complex* Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream, int need_minus_q);
 
     /**
      * \return synchronization lock to Pqk0_tQP array

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -303,7 +303,7 @@ namespace green::gpu {
     void cleanup(bool low_memory_mode, tensor<std::complex<prec>, 4>& Sigmak_stij_host, ztensor<5>& Sigma_tskij_host, bool x2c);
 
     /**
-     * \brief 
+     * \brief Copies the self-energy from the per-k buffer to the full host tensor for non-X2C calculations.
      * 
      */
     void copy_Sigma(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij);

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -325,9 +325,9 @@ namespace green::gpu {
     bool is_busy();
 
     /**
-     * \brief Set the k_red_id_ object
+     * \brief Set the irreducible k-point index for gw_qkpt worker
      * 
-     * \param k
+     * \param k incoming k-point index
      */
     void set_k_red_id(int k) {
       k_red_id_ = k;

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -284,16 +284,16 @@ namespace green::gpu {
     /**
      * \brief Using dressed GW polarization compute self-energy at a given momentum point
      *
-     * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
      * \param Pqk_tQP Dressed polarization bubble
      */
-    void compute_second_tau_contraction(cxx_complex* Sigmak_stij_host = nullptr, cuda_complex* Pqk_tQP = nullptr);
+    void compute_second_tau_contraction(cuda_complex* Pqk_tQP = nullptr);
+
     /**
      * \brief Using dressed GW polarization compute self-energy at a given momentum point (X2C version)
-     * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
+     * 
      * \param Pqk_tQP Dressed polarization bubble
      */
-    void compute_second_tau_contraction_2C(cxx_complex* Sigmak_stij_host = nullptr, cuda_complex* Pqk_tQP = nullptr);
+    void compute_second_tau_contraction_2C(cuda_complex* Pqk_tQP = nullptr);
 
     /**
      * \brief For a given k-point copy self-energy back to a host memory

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -74,7 +74,7 @@ namespace green::gpu {
      * \param need_minus_q we need to get Pqk_tQP_conj_ for a (-q) point
      * \return Pqk_tQP or Pqk_tQP_conj array for dressed polarization
      */
-    cuda_complex* Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream, int need_minus_q);
+    cuda_complex* Pqk_tQP(cudaEvent_t all_done_event, cudaStream_t calc_stream, int need_minus_q, bool profile=false);
 
     /**
      * \return synchronization lock to Pqk0_tQP array

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -303,13 +303,15 @@ namespace green::gpu {
     void cleanup(bool low_memory_mode, tensor<std::complex<prec>, 4>& Sigmak_stij_host, ztensor<5>& Sigma_tskij_host, bool x2c);
 
     /**
-     * \brief Copies the self-energy from the per-k buffer to the full host tensor for non-X2C calculations.
+     * \brief Copy the non-relativistic self-energy from the per-k buffer to the full host tensor.
      * 
+     * \param Sigma_tskij_host Host storage for the full self-energy tensor.
+     * \param Sigmak_stij Self-energy tensor for a given momentum point.
      */
     void copy_Sigma(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij);
 
     /**
-     * \brief Copy 2-component self-energy data from device to host storage.
+     * \brief Copy 2-component self-energy from per-k buffer to full host tensor.
      * 
      * \param Sigma_tskij_host Host storage for the full self-energy tensor.
      * \param Sigmak_stij Self-energy tensor for a given momentum point.
@@ -472,9 +474,7 @@ namespace green::gpu {
   void wait_and_clean_qkpts(std::vector<gw_qkpt<prec>*>& qkpts, bool low_memory_mode,
                             tensor<std::complex<prec>,4>& Sigmak_stij_host,
                             ztensor<5>& Sigma_tskij_shared, bool x2c) {
-    static int pos = 0;
-    pos++;
-    if (pos >= qkpts.size()) pos = 0;
+    if (int pos >= qkpts.size()) pos = 0;
     for (pos = 0; pos < qkpts.size(); pos++) {
       // wait for qkpt to finish its tasks, then cleanup
       while (qkpts[pos]->is_busy()) {

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -474,8 +474,7 @@ namespace green::gpu {
   void wait_and_clean_qkpts(std::vector<gw_qkpt<prec>*>& qkpts, bool low_memory_mode,
                             tensor<std::complex<prec>,4>& Sigmak_stij_host,
                             ztensor<5>& Sigma_tskij_shared, bool x2c) {
-    if (int pos >= qkpts.size()) pos = 0;
-    for (pos = 0; pos < qkpts.size(); pos++) {
+    for (int pos = 0; pos < qkpts.size(); pos++) {
       // wait for qkpt to finish its tasks, then cleanup
       while (qkpts[pos]->is_busy()) {
         continue;

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -262,25 +262,6 @@ namespace green::gpu {
      */
     void write_P0(int t, cuda_complex* Pqk0_tQP, int* Pqk0_tQP_lock);
 
-    // /**
-    //  * \brief Using dressed GW polarization compute self-energy at a given momentum point
-    //  * 
-    //  * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
-    //  * \param Pqk_tQP Dressed polarization bubble
-    //  * \param Sigma_tskij_host host copy of full self-energy for MPI task assigned to the current device
-    //  */
-    // void async_compute_second_tau_contraction(ztensor<5>& Sigma_tskij_host, cxx_complex* Sigma_stij_host=nullptr,
-    //                                           cuda_complex* Pqk_tQP=nullptr);
-    // /**
-    //  * \brief Using dressed GW polarization compute self-energy at a given momentum point (X2C version)
-    //  * 
-    //  * \param Sigmak_stij_host Host stored array for Self-energy at a given momentum point
-    //  * \param Pqk_tQP Dressed polarization bubble
-    //  * \param Sigma_tskij_host host copy of full self-energy for MPI task assigned to the current device
-    //  */
-    // void async_compute_second_tau_contraction_2C(ztensor<5>& Sigma_tskij_host, cxx_complex* Sigma_stij_host=nullptr,
-    //                                              cuda_complex* Pqk_tQP=nullptr);
-
     /**
      * \brief Using dressed GW polarization compute self-energy at a given momentum point
      *
@@ -492,9 +473,6 @@ namespace green::gpu {
   void wait_and_clean_qkpts(std::vector<gw_qkpt<prec>*>& qkpts, bool low_memory_mode,
                             tensor<std::complex<prec>,4>& Sigmak_stij_host,
                             ztensor<5>& Sigma_tskij_shared, bool x2c) {
-    // if (!utils::context.global_rank) {
-    //   std::cout << "\nDEBUG: Waiting for all qkpts to finish working\n" << std::endl;
-    // }
     static int pos = 0;
     pos++;
     if (pos >= qkpts.size()) pos = 0;
@@ -505,10 +483,6 @@ namespace green::gpu {
       }
       qkpts[pos]->cleanup(low_memory_mode, Sigmak_stij_host, Sigma_tskij_shared, x2c);
     }
-    // if (!utils::context.global_rank) {
-    //   std::cout << "\nDEBUG: Cleanup of qkpts completed\n" << std::endl;
-    // }
-    return;
   }
 
 }  // namespace green::gpu

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -317,7 +317,7 @@ namespace green::gpu {
     void copy_Sigma_2c(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij);
 
     /**
-     * \brief Check if cuda devices are budy
+     * \brief Check if cuda devices are busy
      * \return true if asynchronous calculations are still running
      */
     bool is_busy();

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -319,7 +319,7 @@ namespace green::gpu {
      * \param Sigma_tskij_host - Host stored full self-energy object for each device
      * \param x2c - use x2c specific functions or not
      */
-    void cleanup(bool low_memory_mode, cxx_complex* Sigmak_stij_host, ztensor<5>& Sigma_tskij_host, bool x2c);
+    void cleanup(bool low_memory_mode, tensor<std::complex<prec>, 4>& Sigmak_stij_host, ztensor<5>& Sigma_tskij_host, bool x2c);
 
     /**
      * \brief 

--- a/src/green/gpu/cugw_qpt.h
+++ b/src/green/gpu/cugw_qpt.h
@@ -309,11 +309,10 @@ namespace green::gpu {
     void copy_Sigma(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij);
 
     /**
-     * \brief 
+     * \brief Copy 2-component self-energy data from device to host storage.
      * 
-     * \param Sigma_tskij_host 
-     * \param Sigmak_stij 
-     * \param k_id 
+     * \param Sigma_tskij_host Host storage for the full self-energy tensor.
+     * \param Sigmak_stij Self-energy tensor for a given momentum point.
      */
     void copy_Sigma_2c(ztensor<5>& Sigma_tskij_host, tensor<std::complex<prec>, 4>& Sigmak_stij);
 

--- a/src/green/gpu/gpu_kernel.h
+++ b/src/green/gpu/gpu_kernel.h
@@ -66,7 +66,7 @@ namespace green::gpu {
      */
     inline void set_shared_Coulomb() {
       if (_coul_int_reading_type == as_a_whole) {
-        statistics.start("Read");
+        statistics.start("Allocate shared Coulomb");
         // Allocate Coulomb integrals in double precision and cast them to single precision whenever needed
         allocate_shared_Coulomb(&_Vk1k2_Qij);
         statistics.end();

--- a/src/green/gpu/gpu_kernel.h
+++ b/src/green/gpu/gpu_kernel.h
@@ -66,7 +66,7 @@ namespace green::gpu {
      */
     inline void set_shared_Coulomb() {
       if (_coul_int_reading_type == as_a_whole) {
-        statistics.start("Allocate shared Coulomb");
+        statistics.start("read whole integral");
         // Allocate Coulomb integrals in double precision and cast them to single precision whenever needed
         allocate_shared_Coulomb(&_Vk1k2_Qij);
         statistics.end();

--- a/src/green/gpu/gw_gpu_kernel.h
+++ b/src/green/gpu/gw_gpu_kernel.h
@@ -145,10 +145,10 @@ namespace green::gpu {
   protected:
     void gw_innerloop(G_type& g, St_type& sigma_tau) override;
   private:
-      /**
-       * @brief Calculate and print complexity estimation for each device
-       */
-      void complexity_estimation();
+    /**
+     * @brief Calculate and print complexity estimation for each device
+     */
+    void complexity_estimation();
 
     template <typename prec>
     void compute_gw_selfenergy(G_type& g, St_type& sigma_tau);

--- a/src/green/gpu/gw_gpu_kernel.h
+++ b/src/green/gpu/gw_gpu_kernel.h
@@ -186,7 +186,6 @@ namespace green::gpu {
   private:
     /**
      * @brief Calculate and print complexity estimation for each device
-     * 
      */
     void complexity_estimation();
 

--- a/src/green/gpu/gw_gpu_kernel.h
+++ b/src/green/gpu/gw_gpu_kernel.h
@@ -87,10 +87,9 @@ namespace green::gpu {
 
     /**
      * \brief calculate effective floating points operations per second reached on GPU.
-     * This is not representative of the GPU capabilities, but instead, accounts for read/write overheads.
-     * The value is entirely in the context Green-MBPT solver.
+     * This is not representative of the GPU capabilities, but instead, includes read/write overheads.
      */
-    void flops_achieved(MPI_Comm comm);
+    void flops_achieved();
 
     /**
      * \brief print the effective FLOPs achieved for the iteration.
@@ -146,7 +145,10 @@ namespace green::gpu {
   protected:
     void gw_innerloop(G_type& g, St_type& sigma_tau) override;
   private:
-    void complexity_estimation();
+      /**
+       * @brief Calculate and print complexity estimation for each device
+       */
+      void complexity_estimation();
 
     template <typename prec>
     void compute_gw_selfenergy(G_type& g, St_type& sigma_tau);
@@ -182,6 +184,10 @@ namespace green::gpu {
   protected:
     void gw_innerloop(G_type& g, St_type& sigma_tau) override;
   private:
+    /**
+     * @brief Calculate and print complexity estimation for each device
+     * 
+     */
     void complexity_estimation();
 
     template<typename prec>

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -48,7 +48,7 @@ namespace green::gpu {
 
       if (!utils::context.global_rank && _verbose > 1) {
         std::cout << "############ Total GW Operations per Iteration ############" << std::endl;
-        std::cout << "Total:         " << total_flop_count << std::endl;
+        std::cout << "Total:         " << _flop_count << std::endl;
         std::cout << "First matmul:  " << flop_count_firstmatmul << std::endl;
         std::cout << "Fourier:       " << flop_count_fourier << std::endl;
         std::cout << "Solver:        " << flop_count_solver << std::endl;
@@ -73,7 +73,7 @@ namespace green::gpu {
 
       if (!utils::context.global_rank && _verbose > 1) {
         std::cout << "############ Total Two-Component GW Operations per Iteration ############" << std::endl;
-        std::cout << "Total:         " << total_flop_count << std::endl;
+        std::cout << "Total:         " << _flop_count << std::endl;
         std::cout << "First matmul:  " << flop_count_firstmatmul << std::endl;
         std::cout << "Fourier:       " << flop_count_fourier << std::endl;
         std::cout << "Solver:        " << flop_count_solver << std::endl;

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -137,6 +137,8 @@ namespace green::gpu {
       statistics.end();
       statistics.print(utils::context.global);
       print_effective_flops();
+      // Reset all timing stats for next iteration
+      statistics.reset();
 
       clean_MPI_structure();
       clean_shared_Coulomb();

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -125,7 +125,7 @@ namespace green::gpu {
       MPI_Barrier(utils::context.global);
       sigma_tau.fence();
       // Print effective FLOPs achieved in the calculation
-      flops_achieved(_devices_comm);
+      flops_achieved();
       if (!utils::context.node_rank) {
         if (_devices_comm != MPI_COMM_NULL) statistics.start("selfenergy_reduce");
         utils::allreduce(MPI_IN_PLACE, sigma_tau.object().data(), sigma_tau.object().size()/(_nso*_nso), dt_matrix, matrix_sum_op, utils::context.internode_comm);

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -26,27 +26,40 @@
 
 namespace green::gpu {
     void scalar_gw_gpu_kernel::complexity_estimation() {
+      if (_devices_comm == MPI_COMM_NULL) return;
+      // Get number of k-points assigned to each device
+      size_t ink_on_device = 1 + (_ink - 1 - _devices_rank) / _devices_size;
       // Calculate the complexity of GW
       double NQsq=(double)_NQ*_NQ;
       //first set of matmuls
-      double flop_count_firstmatmul= _ink*_nk*_ns*_nts/2.*(
+      double flop_count_firstmatmul = ink_on_device*_nk*_ns*_nts/2.*(
 		      matmul_cost(_nao*_NQ, _nao, _nao) //X1_t_mQ = G_t_p * V_pmQ;
-		      +matmul_cost(_NQ*_nao, _nao, _nao)//X2_Pt_m = (V_Pt_n)* * G_m_n;
-		      +matmul_cost(_NQ, _naosq, _NQ)    //Pq0_QP=X2_Ptm Q1_tmQ
+		      + matmul_cost(_NQ*_nao, _nao, _nao)//X2_Pt_m = (V_Pt_n)* * G_m_n;
+		      + matmul_cost(_NQ, _naosq, _NQ)    //Pq0_QP=X2_Ptm Q1_tmQ
 		      );
-      double flop_count_fourier=_ink*(matmul_cost(NQsq, _nts, _nw_b)+matmul_cost(NQsq, _nw_b, _nts)); //Fourier transform forward and back
-      double flop_count_solver=2./3.*_ink*_nw_b*(NQsq*_NQ+NQsq); //approximate LU and backsubst cost (note we are doing cholesky which is cheaper
+      double flop_count_fourier = ink_on_device*(
+        matmul_cost(NQsq, _nts, _nw_b) + matmul_cost(NQsq, _nw_b, _nts)
+      ); //Fourier transform forward and back
+      double flop_count_solver = 2./3.*ink_on_device*_nw_b*(NQsq*_NQ+NQsq); //approximate LU and backsubst cost (note we are doing cholesky which is cheaper
       //secondset of matmuls
-      double flop_count_secondmatmul=_ink*_nk*_ns*_nts*(
+      double flop_count_secondmatmul = ink_on_device*_nk*_ns*_nts*(
 		      matmul_cost(_NQ*_nao, _nao, _nao) //Y1_Qin = V_Qim * G1_mn;
-		      +matmul_cost(_naosq, _NQ, _NQ)    //Y2_inP = Y1_Qin * Pq_QP
-		      +matmul_cost(_nao, _NQ*_nao, _nao)//Sigma_ij = Y2_inP V_nPj
+		      + matmul_cost(_naosq, _NQ, _NQ)    //Y2_inP = Y1_Qin * Pq_QP
+		      + matmul_cost(_nao, _NQ*_nao, _nao)//Sigma_ij = Y2_inP V_nPj
 		      );
-      _flop_count= flop_count_firstmatmul+flop_count_fourier+flop_count_solver+flop_count_secondmatmul;
+      _flop_count = flop_count_firstmatmul + flop_count_fourier + flop_count_solver + flop_count_secondmatmul;
+
+      // Sum over all devices to get toal FLOP count; but don't broadcast back since each device only needs its own flop count to calculate achieved FLOPs
+      double total_flop_count = _flop_count;
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_firstmatmul, 1, MPI_DOUBLE, MPI_SUM, _devices_comm);
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_fourier, 1, MPI_DOUBLE, MPI_SUM, _devices_comm);
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_solver, 1, MPI_DOUBLE, MPI_SUM, _devices_comm);
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_secondmatmul, 1, MPI_DOUBLE, MPI_SUM, _devices_comm);
+      MPI_Allreduce(MPI_IN_PLACE, &total_flop_count, 1, MPI_DOUBLE, MPI_SUM, _devices_comm);
 
       if (!utils::context.global_rank && _verbose > 1) {
         std::cout << "############ Total GW Operations per Iteration ############" << std::endl;
-        std::cout << "Total:         " << _flop_count << std::endl;
+        std::cout << "Total:         " << total_flop_count << std::endl;
         std::cout << "First matmul:  " << flop_count_firstmatmul << std::endl;
         std::cout << "Fourier:       " << flop_count_fourier << std::endl;
         std::cout << "Solver:        " << flop_count_solver << std::endl;
@@ -56,22 +69,33 @@ namespace green::gpu {
     }
 
     void x2c_gw_gpu_kernel::complexity_estimation() {
+      if (_devices_comm == MPI_COMM_NULL) return;
+      // Get number of k-points assigned to each device
+      size_t ink_on_device = 1 + (_ink - 1 - _devices_rank) / _devices_size;
       // Calculate the complexity of GW
       // TODO virtual function for complexity calculation
       double NQsq=(double)_NQ*_NQ;
       //first set of matmuls
       // Doesn't fit for generalized GW.
-      double flop_count_firstmatmul= _ink*_nk*4*_nts/2.*
+      double flop_count_firstmatmul= ink_on_device*_nk*4*_nts/2.*
                                      (matmul_cost(_nao*_NQ, _nao, _nao)+matmul_cost(_nao, _NQ*_nao, _nao)+matmul_cost(_NQ, _NQ, _naosq));
-      double flop_count_fourier=_ink*(matmul_cost(NQsq, _nts, _nw_b)+matmul_cost(NQsq, _nw_b, _nts)); //Fourier transform forward and back
-      double flop_count_solver=2./3.*_ink*_nw_b*(NQsq*_NQ+NQsq); //approximate LU and backsubst cost
+      double flop_count_fourier=ink_on_device*(matmul_cost(NQsq, _nts, _nw_b)+matmul_cost(NQsq, _nw_b, _nts)); //Fourier transform forward and back
+      double flop_count_solver=2./3.*ink_on_device*_nw_b*(NQsq*_NQ+NQsq); //approximate LU and backsubst cost
       //secondset of matmuls
-      double flop_count_secondmatmul=_ink*_nk*4*_nts*(matmul_cost(_nao*_NQ, _nao, _nao)+matmul_cost(_NQ, _naosq, _NQ)+matmul_cost(_nao, _nao, _NQ*_nao));
+      double flop_count_secondmatmul=ink_on_device*_nk*4*_nts*(matmul_cost(_nao*_NQ, _nao, _nao)+matmul_cost(_NQ, _naosq, _NQ)+matmul_cost(_nao, _nao, _NQ*_nao));
       _flop_count= flop_count_firstmatmul+flop_count_fourier+flop_count_solver+flop_count_secondmatmul;
+
+      // Sum over all devices to get toal FLOP count; but don't broadcast back since each device only needs its own flop count to calculate achieved FLOPs
+      double total_flop_count = _flop_count;
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_firstmatmul, 1, MPI_DOUBLE, MPI_SUM, comm_device);
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_fourier, 1, MPI_DOUBLE, MPI_SUM, comm_device);
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_solver, 1, MPI_DOUBLE, MPI_SUM, comm_device);
+      MPI_Allreduce(MPI_IN_PLACE, &flop_count_secondmatmul, 1, MPI_DOUBLE, MPI_SUM, comm_device);
+      MPI_Allreduce(MPI_IN_PLACE, &total_flop_count, 1, MPI_DOUBLE, MPI_SUM, comm_device);
 
       if (!utils::context.global_rank && _verbose > 1) {
         std::cout << "############ Total Two-Component GW Operations per Iteration ############" << std::endl;
-        std::cout << "Total:         " << _flop_count << std::endl;
+        std::cout << "Total:         " << total_flop_count << std::endl;
         std::cout << "First matmul:  " << flop_count_firstmatmul << std::endl;
         std::cout << "Fourier:       " << flop_count_fourier << std::endl;
         std::cout << "Solver:        " << flop_count_solver << std::endl;
@@ -84,7 +108,7 @@ namespace green::gpu {
       MPI_Datatype dt_matrix = utils::create_matrix_datatype<std::complex<double>>(_nso*_nso);
       MPI_Op matrix_sum_op = utils::create_matrix_operation<std::complex<double>>();
       statistics.start("total");
-      statistics.start("Initialization");
+      statistics.start("Initialization: CPU");
       sigma_tau.fence();
       if (!utils::context.node_rank) sigma_tau.object().set_zero();
       sigma_tau.fence();
@@ -122,32 +146,34 @@ namespace green::gpu {
       MPI_Op_free(&matrix_sum_op);
     }
 
-    void gw_gpu_kernel::flops_achieved(MPI_Comm comm) {
+    void gw_gpu_kernel::flops_achieved() {
+      if (_devices_comm == MPI_COMM_NULL) return;
       double gpu_time=0.;
-      if (comm != MPI_COMM_NULL) {
-        utils::event_t& cugw_event = statistics.event("Solve cuGW");
-        if (!cugw_event.active) {
-          gpu_time = cugw_event.duration;
-        } else {
-          throw std::runtime_error("'Solve cuGW' still active, but it should not be.");
-        }
-      }
-
-      if (!utils::context.global_rank) {
-        MPI_Reduce(MPI_IN_PLACE, &gpu_time, 1, MPI_DOUBLE, MPI_SUM, 0, utils::context.global);
+      utils::event_t& cugw_event = statistics.event("Solve cuGW");
+      if (!cugw_event.active) {
+        gpu_time = cugw_event.duration;
       } else {
-        MPI_Reduce(&gpu_time, &gpu_time, 1, MPI_DOUBLE, MPI_SUM, 0, utils::context.global);
+        throw std::runtime_error("'Solve cuGW' still active, but it should not be.");
       }
-
       _eff_flops = _flop_count / gpu_time;
     }
 
     void gw_gpu_kernel::print_effective_flops() {
+      if (_devices_comm == MPI_COMM_NULL) return;
+      double average_eff_flops = _eff_flops;
+      double max_eff_flops = _eff_flops;
+      double min_eff_flops = _eff_flops;
+      MPI_Reduce(&average_eff_flops, &max_eff_flops, 1, MPI_DOUBLE, MPI_MAX, 0, _devices_comm);
+      MPI_Reduce(&average_eff_flops, &min_eff_flops, 1, MPI_DOUBLE, MPI_MIN, 0, _devices_comm);
+      MPI_Reduce(&average_eff_flops, &average_eff_flops, 1, MPI_DOUBLE, MPI_SUM, 0, _devices_comm);
+      average_eff_flops /= _devCount_total;
       if (!utils::context.global_rank && _verbose > 1) {
         auto old_precision = std::cout.precision();
         std::cout << std::setprecision(6);
         std::cout << "===================   GPU Performance   ====================" << std::endl;
-        std::cout << "Effective FLOPs in the GW iteration: " << _eff_flops / 1.0e9 << " Giga flops." << std::endl;
+        std::cout << "Average GFLOPs achieved in the GW iteration: " << average_eff_flops / (1024 * 1024 * 1024) << std::endl;
+        std::cout << "Minimum GFLOPs achieved in the GW iteration: " << min_eff_flops / (1024 * 1024 * 1024) << std::endl;
+        std::cout << "Maximum GFLOPs achieved in the GW iteration: " << max_eff_flops / (1024 * 1024 * 1024) << std::endl;
         std::cout << "============================================================" << std::endl;
         std::cout << std::setprecision(old_precision);
       }
@@ -173,7 +199,7 @@ namespace green::gpu {
     void scalar_gw_gpu_kernel::compute_gw_selfenergy(G_type& g, St_type& sigma_tau) {
       // check devices' free space and space requirements
       GW_check_devices_free_space();
-      statistics.start("Initialization");
+      statistics.start("Initialization: GPU");
       cugw_utils<prec> cugw(_nts, _nt_batch, _nw_b, _ns, _nk, _ink, _nqkpt, _NQ, _nao, g.object(), _low_device_memory,
                             _ft.Ttn_FB(), _ft.Tnt_BF(), _cuda_lin_solver, utils::context.global_rank, utils::context.node_rank,
                             _devCount_per_node);
@@ -185,7 +211,7 @@ namespace green::gpu {
                                          tensor<std::complex<prec>,3>& V_Qpm, std::complex<double> *Vk1k2_Qij,
                                          tensor<std::complex<prec>,4>&Gk_smtij, tensor<std::complex<prec>,4>&Gk1_stij,
                                          bool need_minus_k, bool need_minus_k1) {
-        statistics.start("read");
+        statistics.start("Read Integrals", true);
         int q = k_vector[2];
         if (_coul_int_reading_type == chunks) {
           read_next(k_vector);
@@ -203,7 +229,7 @@ namespace green::gpu {
                                         tensor<std::complex<prec>,3>& V_Qim, std::complex<double> *Vk1k2_Qij,
                                         tensor<std::complex<prec>,4>&Gk1_stij,
                                         bool need_minus_k1) {
-        statistics.start("read");
+        statistics.start("Read Integrals", true);
         int q = k_vector[1];
         if (_coul_int_reading_type == chunks) {
           read_next(k_vector);
@@ -222,7 +248,7 @@ namespace green::gpu {
       // and do MPIAllreduce on CPU later on. Since the number of processes with a GPU is very
       // limited, the additional memory overhead is fairly limited.
       ztensor<5> Sigma_tskij_host_local(_nts, _ns, _ink, _nao, _nao);
-      statistics.start("Solve cuGW");
+      statistics.start("Solve cuGW", false);
       cugw.solve(_nts, _ns, _nk, _ink, _nao, _bz_utils.symmetry().reduced_to_full(), _bz_utils.symmetry().full_to_reduced(),
                  _Vk1k2_Qij, Sigma_tskij_host_local, _devices_rank, _devices_size, _low_device_memory, _verbose,
                  irre_pos, mom_cons, r1, r2);
@@ -308,7 +334,7 @@ namespace green::gpu {
                                          tensor<std::complex<prec>,4>&Gk_4mtij, tensor<std::complex<prec>,4>&Gk1_4tij,
                                          bool need_minus_k, bool need_minus_k1) {
 
-          statistics.start("read");
+          statistics.start("Read Integrals", true);
           int q = k_vector[2];
           if (q == 0 or _coul_int_reading_type == chunks) {
             read_next(k_vector);
@@ -324,7 +350,7 @@ namespace green::gpu {
                                          tensor<std::complex<prec>,3>& V_Qim, std::complex<double> *Vk1k2_Qij,
                                          tensor<std::complex<prec>,4>&Gk1_4tij,
                                          bool need_minus_k1) {
-          statistics.start("read");
+          statistics.start("Read Integrals", true);
           int q = k_vector[1];
           if (q == 0 or _coul_int_reading_type == chunks) {
             read_next(k_vector);


### PR DESCRIPTION
The PR proposes asynchronous logic for the copy of self-energy results from D2H.

In the current version, we use `cudaMemcpy` which is a blocking call, i.e., all subsequent qkpt workers wait for the data transfer before starting to read integrals from filesystem. 

The Self-energy computation blocks become highly efficient and keep the GPU busy most of the time.