### PR TITLE
Optimize nt_batch automatically to improve performance

### DIFF
--- a/src/green/gpu/gpu_factory.h
+++ b/src/green/gpu/gpu_factory.h
@@ -98,7 +98,7 @@ namespace green::gpu {
                                LinearSolverType::LU);
     p.define<bool>("cuda_low_gpu_memory", "GPU Device has small amount of memory");
     p.define<bool>("cuda_low_cpu_memory", "Host has small amount of memory, we will read Coulomb integrals in chunks");
-    p.define<size_t>("nt_batch", "Size of tau batch in cuda GW solver", 1);
+    p.define<size_t>("nt_batch", "Size of tau batch in cuda GW solver (default: value will be determined to maximize performance)", 0);
   }
 
 }  // namespace green::mbpt

--- a/src/green/gpu/gpu_factory.h
+++ b/src/green/gpu/gpu_factory.h
@@ -98,7 +98,7 @@ namespace green::gpu {
                                LinearSolverType::LU);
     p.define<bool>("cuda_low_gpu_memory", "GPU Device has small amount of memory");
     p.define<bool>("cuda_low_cpu_memory", "Host has small amount of memory, we will read Coulomb integrals in chunks");
-    p.define<size_t>("nt_batch", "Size of tau batch in cuda GW solver (default: value will be determined to maximize performance)", 0);
+    p.define<size_t>("nt_batch", "Size of tau batch in cuda GW solver; if set to 0; value will be determined to maximize performance", 0);
   }
 
 }  // namespace green::mbpt

--- a/src/green/gpu/gw_gpu_kernel.h
+++ b/src/green/gpu/gw_gpu_kernel.h
@@ -97,6 +97,15 @@ namespace green::gpu {
      */
     void print_effective_flops();
 
+    /**
+     * \brief optimize the tau batch size based on available memory on GPU
+     * 
+     * \param mem_avail available memory on GPU
+     * \param qpt_size size per qpt object for nt_batch = 1
+     * \param qkpt_size size per qkpt object for nt_batch = 1
+     */
+    void optimize_ntbatch(size_t mem_avail, size_t qpt_size, size_t qkpt_size);
+
     double                      _beta;
     size_t                      _nts;
     size_t                      _nts_b;

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -283,7 +283,7 @@ namespace green::gpu {
       size_t total_memory;
       cudaMemGetInfo(&available_memory, &total_memory);
       // Optimize nt_batch size
-      if (!_devices_rank && _verbose > 1)
+      if (!_devices_rank && _verbose > 1 && _nt_batch != 0)
         ss << "Using user specified nt_batch value" << std::endl;
       else
         ss << "Optimizing nt_batch value to maximize performance" << std::endl;

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -287,10 +287,12 @@ namespace green::gpu {
       size_t total_memory;
       cudaMemGetInfo(&available_memory, &total_memory);
       // Optimize nt_batch size
-      if (!_devices_rank && _verbose > 1 && _nt_batch != 0)
-        ss << "Using user specified nt_batch value" << std::endl;
-      else
-        ss << "Optimizing nt_batch value to maximize performance" << std::endl;
+      if (!_devices_rank && _verbose > 1) {
+        if (_nt_batch != 0)
+          ss << "Using user specified nt_batch value" << std::endl;
+        else
+          ss << "Optimizing nt_batch value to maximize performance" << std::endl;
+      }
       optimize_ntbatch(available_memory, qpt_size, qkpt_size);
       // Recalculate qkpt_size with the (possibly) updated _nt_batch value
       qkpt_size = (!_sp) ? gw_qkpt<double>::size(_nao, _NQ, _nts, _nt_batch, _ns) : gw_qkpt<float>::size(_nao, _NQ, _nts, _nt_batch, _ns);

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -288,6 +288,8 @@ namespace green::gpu {
       else
         ss << "Optimizing nt_batch value to maximize performance" << std::endl;
       optimize_ntbatch(available_memory, qpt_size, qkpt_size);
+      // Recalculate qkpt_size with the (possibly) updated _nt_batch value
+      qkpt_size = (!_sp) ? gw_qkpt<double>::size(_nao, _NQ, _nts, _nt_batch, _ns) : gw_qkpt<float>::size(_nao, _NQ, _nts, _nt_batch, _ns);
       if (!_devices_rank && _verbose > 1) ss << "size of tau batch: " << _nt_batch << std::endl;
       if (!_devices_rank && _verbose > 1) ss << "size per qpt: " << qpt_size / (1024 * 1024. * 1024.) << " GB " << std::endl;
       _nqkpt = std::min(std::min(size_t((available_memory * 0.8 - qpt_size) / qkpt_size), 16ul), _ink);

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -294,19 +294,18 @@ namespace green::gpu {
       size_t total_memory;
       cudaMemGetInfo(&available_memory, &total_memory);
       // Optimize nt_batch size
+      optimize_ntbatch(available_memory, qpt_size, qkpt_size);
+      // Recalculate qkpt_size with the (possibly) updated _nt_batch value
+      qkpt_size = (!_sp) ? gw_qkpt<double>::size(_nao, _NQ, _nts, _nt_batch, _ns) : gw_qkpt<float>::size(_nao, _NQ, _nts, _nt_batch, _ns);
+      _nqkpt = std::min(std::min(size_t((available_memory * 0.8 - qpt_size) / qkpt_size), 16ul), _ink);
+      // Print memory info
       if (!_devices_rank && _verbose > 1) {
         if (_nt_batch != 0)
           ss << "Using user specified nt_batch value" << std::endl;
         else
-          ss << "Optimizing nt_batch value to maximize performance" << std::endl;
-      }
-      optimize_ntbatch(available_memory, qpt_size, qkpt_size);
-      // Recalculate qkpt_size with the (possibly) updated _nt_batch value
-      qkpt_size = (!_sp) ? gw_qkpt<double>::size(_nao, _NQ, _nts, _nt_batch, _ns) : gw_qkpt<float>::size(_nao, _NQ, _nts, _nt_batch, _ns);
-      if (!_devices_rank && _verbose > 1) ss << "size of tau batch: " << _nt_batch << std::endl;
-      if (!_devices_rank && _verbose > 1) ss << "size per qpt: " << qpt_size / (1024 * 1024. * 1024.) << " GB " << std::endl;
-      _nqkpt = std::min(std::min(size_t((available_memory * 0.8 - qpt_size) / qkpt_size), 16ul), _ink);
-      if (!_devices_rank && _verbose > 1) {
+          ss << "Optimized nt_batch value to maximize performance" << std::endl;
+        ss << "size of tau batch: " << _nt_batch << std::endl;
+        ss << "size per qpt: " << qpt_size / (1024 * 1024. * 1024.) << " GB " << std::endl;
         ss << "size per qkpt: " << qkpt_size / (1024 * 1024. * 1024.) << " GB " << std::endl;
         ss << "available memory: " << available_memory / (1024 * 1024. * 1024.) << " GB " << " of total: "
                   << total_memory / (1024 * 1024. * 1024.) << " GB. " << std::endl;

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -177,6 +177,10 @@ namespace green::gpu {
       size_t size_per_t = qkpt_size - size_fix;
       // Optimize nt_batch
       mem_avail_for_qkpt /= 2; // create at least 2 qkpt workers
+      if (mem_avail_for_qkpt < size_fix) {
+        _nt_batch = 1; // Set to minimum or handle error
+        return;
+      }
       mem_avail_for_qkpt -= size_fix;
       _nt_batch = std::min(static_cast<size_t>(mem_avail_for_qkpt / size_per_t), static_cast<size_t>(_nts));
       // If nt_batch is large and (nts - nt_batch) is small, then we might be better off with nt_batch = nts / 2

--- a/src/gw_gpu_kernel.cpp
+++ b/src/gw_gpu_kernel.cpp
@@ -171,7 +171,7 @@ namespace green::gpu {
       // If user provided nt_batch size, use it directly
       if (_nt_batch != 0) return;
       // Estimate optimal nt_batch size
-      size_t mem_avail_for_qkpt = available_memory * 0.8 - qpt_size; // leave 20% memory for other usages
+      size_t mem_avail_for_qkpt = mem_avail * 0.8 - qpt_size; // leave 20% memory for other usages
       // qkpt_size = size_fix + size_per_t * nt_batch
       size_t size_fix = (!_sp) ? gw_qkpt<double>::size(_nao, _NQ, _nts, _nt_batch, _ns) : gw_qkpt<float>::size(_nao, _NQ, _nts, _nt_batch, _ns);
       size_t size_per_t = qkpt_size - size_fix;

--- a/test/cu_solver_test.cpp
+++ b/test/cu_solver_test.cpp
@@ -95,7 +95,7 @@ void solve_hf(const std::string& input, const std::string& int_hf, const std::st
 }
 
 
-void solve_gw(const std::string& input, const std::string& int_f, const std::string& data, const std::string& lin, const std::string& mem, bool sp) {
+void solve_gw(const std::string& input, const std::string& int_f, const std::string& data, const std::string& lin, const std::string& mem, bool sp, const std::string& nt_batch) {
   auto        p           = green::params::params("DESCR");
   std::string input_file  = TEST_PATH + input;
   std::string df_int_path = TEST_PATH + int_f;
@@ -104,7 +104,7 @@ void solve_gw(const std::string& input, const std::string& int_f, const std::str
   std::string args =
       "test --restart 0 --itermax 1 --E_thr 1e-13 --mixing_type SIGMA_DAMPING --damping 0.8 --input_file=" + input_file +
       " --BETA 100 --grid_file=" + grid_file + " --dfintegral_file=" + df_int_path + " --verbose=5 " +
-      " --cuda_low_gpu_memory " + mem + " --cuda_low_cpu_memory " + mem + " --cuda_linear_solver=" + lin;
+      " --cuda_low_gpu_memory " + mem + " --cuda_low_cpu_memory " + mem + " --cuda_linear_solver=" + lin + " --nt_batch=" + nt_batch;
   green::grids::define_parameters(p);
   green::symmetry::define_parameters(p);
   green::gpu::custom_kernel_parameters(p);
@@ -161,22 +161,43 @@ void solve_gw(const std::string& input, const std::string& int_f, const std::str
 
 TEST_CASE("GPU Solver") {
   SECTION("GW_LU") {
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "false", false);
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "true", false);
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "false", true);
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "true", true);
+    // solve_gw(input_file, df_int_path, test_file, linear_solver, low_mem, sp_precision, nt_batch);
+    // automatically optimize nt_batch
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "false", false, "0");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "true", false, "0");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "false", true, "0");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "true", true, "0");
+    // set nt_batch = 1
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "false", false, "1");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "true", false, "1");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "false", true, "1");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "LU", "true", true, "1");
   }
   SECTION("GW_Cholesky") {
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "false", false);
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "false", true);
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "true", false);
-    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "true", true);
+    // solve_gw(input_file, df_int_path, test_file, linear_solver, low_mem, sp_precision, nt_batch);
+    // automatically optimize nt_batch
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "false", false, "0");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "false", true, "0");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "true", false, "0");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "true", true, "0");
+    // set nt_batch = 1
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "false", false, "1");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "false", true, "1");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "true", false, "1");
+    solve_gw("/GW/input.h5", "/GW/df_int", "/GW/data.h5", "Cholesky", "true", true, "1");
   }
   SECTION("GW_X2C") {
-    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "false", false);
-    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "false", true);
-    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "true", false);
-    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "true", true);
+    // solve_gw(input_file, df_int_path, test_file, linear_solver, low_mem, sp_precision, nt_batch);
+    // automatically optimize nt_batch
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "false", false, "0");
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "false", true, "0");
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "true", false, "0");
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "true", true, "0");
+    // set nt_batch = 1
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "false", false, "1");
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "false", true, "1");
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "true", false, "1");
+    solve_gw("/GW_X2C/input.h5", "/GW_X2C/df_hf_int", "/GW_X2C/data.h5", "LU", "true", true, "1");
   }
 
   SECTION("HF") {


### PR DESCRIPTION
GW kernel uses `cublas::gemm_strided_batched` which performs the best when batch size is large.
This PR proposes automatic optimization of `nt_batch` to achieve high optimal performance, with the following logic:
* Set default value: `nt_batch = 0`
* If `nt_batch == 0`, optimize value for better performance.
* Otherwise, use specified value.

Optimization logic:
* Keep at least 2 streams, then maximize `nt_batch`.
* If optimized `nt_batch` is large but `n_tau - nt_batch < n_tau / 4` (i.e., second batch is small), we opt instead for `nt_batch = n_tau / 2` -- this is debatable but for both small and large applications, this shouldn't make much of a difference.