### PR TITLE
fix: replace removed cudaDeviceProp::memoryClockRate for CUDA 13 compatibility

### DIFF
--- a/src/cuda_check.cpp
+++ b/src/cuda_check.cpp
@@ -36,7 +36,9 @@ void check_for_cuda(MPI_Comm global_comm, int global_rank, int &devCount_per_nod
       cudaGetDeviceProperties(&prop, i);
       std::cout<<"Device Number: " << i << std::endl;
       std::cout<<"  Device name: " << prop.name << std::endl;
-      std::cout<<"  Peak Memory Bandwidth (GB/s): "<<2.0*prop.memoryClockRate*(prop.memoryBusWidth/8)/1.0e6<<std::endl;
+      int memClockKHz = 0;
+      cuDeviceGetAttribute(&memClockKHz, CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, i);
+      std::cout<<"  Peak Memory Bandwidth (GB/s): "<<2.0*memClockKHz*(prop.memoryBusWidth/8)/1.0e6<<std::endl;
       std::cout<<"  Compute Capability: "<<prop.major<<"."<<prop.minor<<std::endl;
       std::cout<<"  total global mem: "<<prop.totalGlobalMem/(1024.*1024*1024)<<" GB"<<std::endl;
     }


### PR DESCRIPTION
## Summary

- `cudaDeviceProp::memoryClockRate` was removed in CUDA 13, causing a compile error in `cuda_check.cpp`.
- Replaced with `cuDeviceGetAttribute(..., CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE, i)`, which returns the same value in kHz and is available across all CUDA versions via the driver API (`cuda.h` is already included).

## Test plan

- [ ] Verify build succeeds with CUDA 13+
- [ ] Verify reported peak memory bandwidth value is unchanged compared to the old `memoryClockRate` path on CUDA 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)