### PR TITLE
fix: remove sm_70 and sm_75 from default GPU architecture list

### DIFF
--- a/cmake/CudaArchitectures.cmake
+++ b/cmake/CudaArchitectures.cmake
@@ -4,11 +4,6 @@ function(define_cuda_architectures)
     message(STATUS "GPU_ARCHS defined as ${GPU_ARCHS}. Generating CUDA code for SM ${GPU_ARCHS}")
     separate_arguments(GPU_ARCHS)
   else()
-    list(APPEND GPU_ARCHS_
-        70
-        75
-      )
-
     if (CUDAToolkit_VERSION VERSION_GREATER_EQUAL 11.0)
       # Ampere GPU (SM80) support is only available in CUDA versions > 11.0
       list(APPEND GPU_ARCHS_ 80)


### PR DESCRIPTION
## Summary

- sm_70 (Volta) and sm_75 (Turing) were dropped in CUDA 13. Having them as unconditional defaults in `CudaArchitectures.cmake` causes a hard build failure (`nvcc fatal: Unsupported gpu architecture 'compute_70'`) on any system with CUDA 13+.
- Removed both from the default list. The minimum default architecture is now sm_80 (Ampere, CUDA ≥ 11.0).
- Users who require Volta/Turing support can still pass `-DGPU_ARCHS="70;75"` explicitly when using a CUDA 12 or older toolchain.

## Test plan

- [ ] Verify default build succeeds on CUDA 13+ without `-DGPU_ARCHS`
- [ ] Verify `-DGPU_ARCHS="70;75"` still works on CUDA 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)